### PR TITLE
hail dependency issue 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,18 +220,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!-- the all artifact is broken in repo, use the default one here  -->
       <groupId>au.csiro.aehrc.third.hail-is</groupId>
       <artifactId>hail_${scala.binary.version}_${spark.binary.version}</artifactId>
       <version>${hail.version}-SNAPSHOT</version>
-      <!--classifier>all</classifier-->
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>au.csiro.aehrc.third.hail-is</groupId>
-      <artifactId>hail_${scala.binary.version}_${spark.binary.version}</artifactId>
-      <version>${hail.version}-SNAPSHOT</version>
-      <classifier>all</classifier>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
problems are addressed in issue #239 
This repo removes the broken dependency hail_2.12_3.1-0.2.74-SNAPSHOT-all.jar from pom.xml.  This dependency was only required during unit test won't affect our runtime execution. The existing dependency hail_2.12_3.1-0.2.74-SNAPSHOT.jar also works well during unit tests. Hence, we remove this redundant and broken one from dependency lists. 